### PR TITLE
change icons to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # CLI Commands :sailboat:
 List of some daily used commands for tech geeks.
 
-- :whale2: [DOCKER](commands/docker/docker.md)
-- :musical_keyboard: [GIT](commands/git/git.md)
-- :shell: [MONGO](commands/mongo/mongo.md)
-- :cyclone: [SCP](commands/scp/scp.md)
-- :zap: [SSH](commands/ssh/ssh.md)
-- :package: [ZIP](commands/zip/zip.md)
+- <img align="left" src="https://img.icons8.com/color/27/000000/cardboard-box.png"> &nbsp;[DOCKER](commands/docker/docker.md)
+
+- <img align="left" src="https://img.icons8.com/color/27/000000/piano.png"> &nbsp;[GIT](commands/git/git.md)
+
+- <img align="left" src="https://img.icons8.com/color/27/000000/shellfish.png"> &nbsp;[MONGO](commands/mongo/mongo.md)
+
+- <img align="left" src="https://img.icons8.com/color/27/000000/cardboard-box.png"> &nbsp;[SCP](commands/scp/scp.md)
+
+- <img align="left" src="https://img.icons8.com/color/27/000000/cloudshot.png"> &nbsp;[SSH](commands/ssh/ssh.md)
+
+- <img align="left" src="https://img.icons8.com/color/27/000000/cardboard-box.png"> &nbsp; [ZIP](commands/zip/zip.md)
 
 # Contributing Guide
 Interested in contributing to this project, check some of our open issues [here](https://github.com/arshadkazmi42/ak-cli/issues).
 
-Read our contrubtion guide [here](CONTRIBUTING.md). 
+Read our contrubtion guide [here](CONTRIBUTING.md).
 
 # Help us
 We would love to get some suggestions or feedbacks for this project.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# CLI Commands :sailboat:
+# CLI Commands <img align="center"   src="https://img.icons8.com/color/48/000000/sailing-ship-small.png">
 List of some daily used commands for tech geeks.
 
-- <img align="left" src="https://img.icons8.com/color/27/000000/cardboard-box.png"> &nbsp;[DOCKER](commands/docker/docker.md)
+- <img align="left" src="https://img.icons8.com/color/27/000000/whale.png"> &nbsp;[DOCKER](commands/docker/docker.md)
 
 - <img align="left" src="https://img.icons8.com/color/27/000000/piano.png"> &nbsp;[GIT](commands/git/git.md)
 
 - <img align="left" src="https://img.icons8.com/color/27/000000/shellfish.png"> &nbsp;[MONGO](commands/mongo/mongo.md)
 
-- <img align="left" src="https://img.icons8.com/color/27/000000/cardboard-box.png"> &nbsp;[SCP](commands/scp/scp.md)
+- <img align="left" src="https://img.icons8.com/doodle/27/000000/merge-vertical.png"> &nbsp;[SCP](commands/scp/scp.md)
 
 - <img align="left" src="https://img.icons8.com/color/27/000000/cloudshot.png"> &nbsp;[SSH](commands/ssh/ssh.md)
 


### PR DESCRIPTION
Fixes #49 
I changed the markdown icons in readme.md to open source images. 

